### PR TITLE
fix(tab_control): recompute layout when maxWidth changes

### DIFF
--- a/lib/src/tab_bar.dart
+++ b/lib/src/tab_bar.dart
@@ -222,11 +222,22 @@ class _SegmentedTabControlState extends State<_SegmentedTabControl>
   }
 
   @override
-  void didUpdateWidget(_SegmentedTabControl oldWidget) {
+  void didUpdateWidget(covariant _SegmentedTabControl oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.controller != oldWidget.controller) {
+
+    final didControllerChange = widget.controller != oldWidget.controller;
+    final didMaxWidthChange = widget.maxWidth != oldWidget.maxWidth;
+
+    if (didMaxWidthChange) {
+      _maxWidth = widget.maxWidth;
+    }
+
+    if (didControllerChange || didMaxWidthChange) {
       _calculateTotalFlex();
       _calculateFlexFactors();
+    }
+
+    if (didControllerChange) {
       _updateTabController();
     }
   }


### PR DESCRIPTION
Update didUpdateWidget to detect maxWidth changes and recalculate _maxWidth, total flex, and flex factors. This ensures the segmented tab control updates its layout correctly after orientation/size changes instead of keeping the initial cached width.