### PR TITLE
feat: Add labelWidget parameter to SegmentTab for custom widget support

### DIFF
--- a/lib/src/tab.dart
+++ b/lib/src/tab.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 class SegmentTab {
   const SegmentTab({
     required this.label,
+    this.labelWidget,
     this.color,
     this.gradient,
     this.selectedTextColor,
@@ -16,8 +17,11 @@ class SegmentTab {
     this.flex = 1,
   });
 
-  /// This text will be displayed on tab.
+  /// Text label used when [labelWidget] is null.
   final String label;
+
+  /// Custom widget for the tab label. If non-null, it overrides [label].
+  final Widget? labelWidget;
 
   /// Tab flex factor
   final int flex;

--- a/lib/src/tab_bar.dart
+++ b/lib/src/tab_bar.dart
@@ -594,17 +594,19 @@ class _Labels extends StatelessWidget {
                 child: Padding(
                   padding: tabPadding,
                   child: Center(
-                    child: AnimatedDefaultTextStyle(
-                      duration: kTabScrollDuration,
-                      curve: Curves.ease,
-                      style: (index == currentIndex) ? selectedTextStyle : textStyle,
-                      child: Text(
-                        tab.label,
-                        overflow: TextOverflow.clip,
-                        maxLines: 1,
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
+                    child: tab.labelWidget != null
+                        ? tab.labelWidget!
+                        : AnimatedDefaultTextStyle(
+                            duration: kTabScrollDuration,
+                            curve: Curves.ease,
+                            style: (index == currentIndex) ? selectedTextStyle : textStyle,
+                            child: Text(
+                              tab.label,
+                              overflow: TextOverflow.clip,
+                              maxLines: 1,
+                              textAlign: TextAlign.center,
+                            ),
+                          ),
                   ),
                 ),
               ),


### PR DESCRIPTION
Changes:

- Add optional `labelWidget` parameter to `SegmentTab` class
- Update rendering logic to prioritize `labelWidget` over `label`
- Maintain backward compatibility (`label` remains required and existing usages keep working)
- Enable richer tab content: icons, badges, and custom widget compositions (e.g. icons, badges, custom layouts)